### PR TITLE
feat: 添加PPTX文件支持

### DIFF
--- a/import os.py
+++ b/import os.py
@@ -31,6 +31,11 @@ except ImportError:
     sr = None
     AudioSegment = None
 
+try:
+    from pptx import Presentation
+except ImportError:
+    Presentation = None
+
 def file_to_text(filepath: str) -> str:
     ext = os.path.splitext(filepath)[1].lower()
     if ext in ['.txt', '.md', '.csv', '.json', '.xml']:
@@ -67,6 +72,14 @@ def file_to_text(filepath: str) -> str:
             except Exception:
                 text = ''
         os.remove(wav_path)
+        return text
+    elif ext in ['.pptx'] and Presentation:
+        prs = Presentation(filepath)
+        text = ''
+        for slide in prs.slides:
+            for shape in slide.shapes:
+                if hasattr(shape, "text"):
+                    text += shape.text + '\n'
         return text
     else:
         raise ValueError(f'不支持的文件类型: {ext}')


### PR DESCRIPTION
## 修改内容
- 新增对 `.pptx` 文件的支持
- 依赖 `python-pptx` 库提取幻灯片文本
- 兼容原有所有文件类型

## 测试方法
1. 安装依赖：`pip install python-pptx`
2. 运行：`python file_converter.py test.pptx`
3. 确认输出包含PPTX中的文字

## 关联Issue
解决 #1 （如果有相关Issue）